### PR TITLE
Adds Modern Nomad and Denitia and Sene to events

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -14,6 +14,14 @@
 - what: G.U.M.P. with NappyNappa
   when: 2017-02-17 8pm
   where: Kirby House Lounge
+  
+- what: Modern Nomad
+  when: 2017-11-14 8pm
+  where: Kirby House Lounge
+
+- what: Denitia and Sene
+  when: 2016-04-22 8pm
+  where: Kirby House Lounge
 
 - what: Grooms
   when: 2016-02-05 8pm


### PR DESCRIPTION
Adds Modern Nomad and Denitia and Sene to the list of events. (Hopefully I send this update to master instead of summer-schedule)